### PR TITLE
feat: make statistics hint text configurable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ name: Build
 on:
   # Trigger the workflow on pushes to only the 'main' branch (this avoids duplicate checks being run e.g. for dependabot pull requests)
   push:
-    branches: [ main ]
+    branches: [ main, feat/* ]
   # Trigger the workflow on any pull request
   pull_request:
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ fun properties(key: String) = project.findProperty(key).toString()
 plugins {
     kotlin("jvm") version "1.7.10"
     kotlin("plugin.serialization") version "1.7.10"
-    id("org.jetbrains.intellij") version "1.8.0"
+    id("org.jetbrains.intellij") version "1.13.0"
     id("org.jetbrains.changelog") version "1.3.1"
 }
 

--- a/src/main/kotlin/org/yh/statistics/Common.kt
+++ b/src/main/kotlin/org/yh/statistics/Common.kt
@@ -1,12 +1,21 @@
 package org.yh.statistics
 
+import org.yh.statistics.StatisticsHintTemplateMarker.*
+
 
 object Constants {
-
     const val NAME = "Statistics View"
     const val DATA_FILE = "stat.log"
     const val GITHUB_URL = "https://github.com/yaohui-wyh/StatisticsView"
     const val MAX_LOG_LINE = 500 * 1000
+}
+
+val DEFAULT_HINT_TEMPLATE = "Last viewed: ${LAST_VIEWED.pattern}. (${OPEN_COUNTS.pattern} times, total ${TOTAL_TIME.pattern})"
+
+enum class StatisticsHintTemplateMarker(val pattern: String, val desc: String) {
+    LAST_VIEWED("{lv}", "Last viewed"),
+    OPEN_COUNTS("{oc}", "Open counts"),
+    TOTAL_TIME("{tm}", "Total viewed time (ms)");
 }
 
 enum class StatisticsAction {

--- a/src/main/kotlin/org/yh/statistics/Extensions.kt
+++ b/src/main/kotlin/org/yh/statistics/Extensions.kt
@@ -49,6 +49,7 @@ val Long.duration: String
     get() {
         val millis = Duration.ofMillis(this)
         return when {
+            millis.toSeconds() <= 0 -> "0s"
             millis.toMinutes() <= 0 -> "${millis.toSeconds()}s"
             millis.toHours() <= 0 -> "${millis.toMinutes()}m"
             millis.toDays() <= 0 -> "${millis.toHours()}h"

--- a/src/main/kotlin/org/yh/statistics/view/MyViewNodeDecorator.kt
+++ b/src/main/kotlin/org/yh/statistics/view/MyViewNodeDecorator.kt
@@ -42,7 +42,7 @@ class MyViewNodeDecorator(private val project: Project) : ProjectViewNodeDecorat
 
     private fun decorateFileNode(file: VirtualFile): String {
         if (!settings.showFileViewStatistics) return ""
-        return dataManager.getFileAggregateResult(file.relativeUrl(project))?.getLastViewedHintText().orEmpty()
+        return dataManager.getFileAggregateResult(file.relativeUrl(project))?.renderStatisticsHint().orEmpty()
     }
 
     private fun decorateDirectoryNode(file: VirtualFile): String {


### PR DESCRIPTION
Implement #1

### How to use

- Download & install the plugin manually from GitHub [workflow](https://github.com/yaohui-wyh/StatisticsView/actions/runs/4224068767) artifact
- Statistics hint text can be rendered using a customized template. Right now there is no configuration panel for the template editing (yet), you can specify the template via JVM Options: <kbd>Help</kbd> -> <kbd>Edit Custom VM Options</kbd>
- For example, if you want to remove the default `Last viewed: ` prefix (see #1), you can specify the template by adding a line to the VM Options:
    ```
    -DstatisticsView.hint.template={lv}. ({oc} times, total {tm})
    ```
- And restart IDE to take effect
    
    <img width="680" alt="image" src="https://user-images.githubusercontent.com/3115235/220128784-4f99dc15-9087-466b-a2af-18e943a7b2d7.png">

- Supported variables in the template:
    - `{lv}` -> last viewed timestamp
    - `{oc}` -> open counts for the file item
    - `{tm}` -> total time (ms)

